### PR TITLE
feat: enable resume pdf download

### DIFF
--- a/src/components/resume-section.tsx
+++ b/src/components/resume-section.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Download, GraduationCap, Code, Briefcase } from "lucide-react";
+import resumePdf from "@/assets/Resume_CAO_4-8-25.pdf";
 
 export function ResumeSection() {
   const skills = {
@@ -36,9 +37,11 @@ export function ResumeSection() {
                 <p className="text-muted-foreground mb-4">
                   Download the complete PDF version of my resume for a detailed overview of my experience and qualifications.
                 </p>
-                <Button className="shadow-elegant">
-                  <Download className="mr-2 h-4 w-4" />
-                  Download PDF Resume
+                <Button asChild className="shadow-elegant">
+                  <a href={resumePdf} download>
+                    <Download className="mr-2 h-4 w-4" />
+                    Download PDF Resume
+                  </a>
                 </Button>
               </CardContent>
             </Card>
@@ -131,4 +134,4 @@ export function ResumeSection() {
       </div>
     </section>
   );
-}
+  }

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -102,5 +103,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- allow resume section to download embedded PDF
- fix lint issues by replacing empty interfaces and using ES module plugin import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b9d830945883228dac241c38307e9c